### PR TITLE
Added flag to enable limiting total rows copied during PortJobs

### DIFF
--- a/src/main/java/com/socrata/datasync/config/CommandLineOptions.java
+++ b/src/main/java/com/socrata/datasync/config/CommandLineOptions.java
@@ -36,6 +36,7 @@ public class CommandLineOptions {
     public static final String PORT_PUBLISH_METHOD = "portPublishMethod";
     public static final String PUBLISH_DESTINATION_DATASET_FLAG = "publishDestinationDataset";
     public static final String DESTINATION_DATASET_TITLE_FLAG = "destinationDatasetTitle";
+    public static final String COPY_ROW_LIMIT_FLAG = "copyRowLimit";
 
     public static final String DEFAULT_JOBTYPE = Jobs.INTEGRATION_JOB.toString();
     public static final String DEFAULT_PUBLISH_VIA_FTP = "false";
@@ -72,6 +73,7 @@ public class CommandLineOptions {
         options.addOption("ppm", PORT_PUBLISH_METHOD, true, "Data Porting Publish Method (upsert or replace) (default: " + DEFAULT_PORT_PUBLISH_METHOD + ") [PortJob]");
         options.addOption("pp",  PUBLISH_DESTINATION_DATASET_FLAG, true, "Publish Destination Dataset (true or false) (default: " + DEFAULT_PUBLISH_DESTINATION_DATASET + ") [PortJob]");
         options.addOption("pdt", DESTINATION_DATASET_TITLE_FLAG, true, "Destination Dataset Title (optional) [PortJob]");
+        options.addOption("l", COPY_ROW_LIMIT_FLAG, true, "Max number of rows to copy with Port Job (default is no limit/copy all rows) [PortJob]");
 
         options.addOption("?", "help", false, "Help");
         options.addOption("v", "version", false, "DataSync version");

--- a/src/main/java/com/socrata/datasync/job/PortJob.java
+++ b/src/main/java/com/socrata/datasync/job/PortJob.java
@@ -38,6 +38,7 @@ public class PortJob extends Job {
     private PublishDataset publishDataset = PublishDataset.working_copy;
 	private String portResult = "";
 	private String destinationDatasetTitle = "";
+    private int copyRowLimit = 0;
 
 
     // Anytime a @JsonProperty is added/removed/updated in this class add 1 to this value
@@ -153,6 +154,11 @@ public class PortJob extends Job {
         this.portResult = portResult;
     }
 
+    @JsonProperty("copyRowLimit")
+    public void setCopyRowLimit(int copyRowLimit) {
+        this.copyRowLimit = copyRowLimit;
+    }
+
     public String getDefaultJobName() { return defaultJobName; }
 
     public boolean validateArgs(CommandLine cmd) {
@@ -203,6 +209,8 @@ public class PortJob extends Job {
         }
         if (cmd.getOptionValue("pdt") != null)
             setDestinationDatasetTitle(cmd.getOptionValue("pdt"));
+        if (cmd.getOptionValue("l") != null)
+            setCopyRowLimit(Integer.parseInt(cmd.getOptionValue("l")));
     }
 
 
@@ -249,7 +257,7 @@ public class PortJob extends Job {
 					sinkSetID = PortUtility.portSchema(loader, creator,
 							sourceSetID, destinationDatasetTitle, userPrefs.getUseNewBackend());
 					PortUtility.portContents(streamExporter, streamUpserter,
-							sourceSetID, sinkSetID, PublishMethod.upsert);
+							sourceSetID, sinkSetID, PublishMethod.upsert, copyRowLimit);
 					noPortExceptions = true;
 				} else if (portMethod.equals(PortMethod.copy_data)) {
                     JobStatus schemaCheck = PortUtility.assertSchemasAreAlike(loader, creator, sourceSetID, sinkSetID);
@@ -257,7 +265,7 @@ public class PortJob extends Job {
                         errorMessage = schemaCheck.getMessage();
                     } else {
                         PortUtility.portContents(streamExporter, streamUpserter,
-							sourceSetID, sinkSetID, publishMethod);
+							sourceSetID, sinkSetID, publishMethod, copyRowLimit);
                         noPortExceptions = true;
                     }
 				} else {

--- a/src/test/java/com/socrata/datasync/TestBase.java
+++ b/src/test/java/com/socrata/datasync/TestBase.java
@@ -72,4 +72,8 @@ public class TestBase
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(configFile, UserPreferencesFile.class);
     }
+
+    protected SocrataConnectionInfo getTestConnectionInfo() {
+        return new SocrataConnectionInfo(DOMAIN, USERNAME, PASSWORD, API_KEY);
+    }
 }


### PR DESCRIPTION
Also added a unit test for the DataSync SDK use case.
