### PR TITLE
Bug: Preview pipe delimited fields in the map fields dialog

### DIFF
--- a/src/main/java/com/socrata/datasync/model/CSVModel.java
+++ b/src/main/java/com/socrata/datasync/model/CSVModel.java
@@ -151,7 +151,15 @@ public class CSVModel extends AbstractTableModel{
     public String getColumnPreview(int columnIndex, int itemsToPreview){
         StringBuffer buf = new StringBuffer();
         for (int i = 0; i < Math.min(itemsToPreview,getRowCount()); i++){
-            buf.append(getValueAt(i,columnIndex));
+            Object value = "N/A";
+            try
+            {
+                value = getValueAt(i,columnIndex);
+            }
+            catch (ArrayIndexOutOfBoundsException e){
+                System.out.println("Row contains different number of columns than expected.  Rows with missing data will be displayed as \"N/A\" in the map fields dialog");
+            }
+            buf.append(value);
             if (i+1 <  Math.min(itemsToPreview,getRowCount()))
                 buf.append(", ");
         }


### PR DESCRIPTION
If the file contained a delimiter that wasn't the default ',' but one of the fields
contained a comma (e.g. 12345|foo,bar) then we would detect a different
number of columns in each row, causing the dialog to fail to render.

This fix simply substitutes "n/a" in the preview (but not the data)
to allow the dialog to render and the customer to fix the delimiter.

Reviewed-by: TBD

QA: Verified with recent NYC upload