### PR TITLE
Bug: EN-833 - Null pointer exception when selecting an item that has already been mapped

### DIFF
--- a/src/main/java/com/socrata/datasync/config/controlfile/FileTypeControl.java
+++ b/src/main/java/com/socrata/datasync/config/controlfile/FileTypeControl.java
@@ -146,4 +146,4 @@ public class FileTypeControl {
 
     public FileTypeControl columnStatistics(boolean u) { columnStatistics = u; return this; }
 
-
+}

--- a/src/main/java/com/socrata/datasync/model/ControlFileModel.java
+++ b/src/main/java/com/socrata/datasync/model/ControlFileModel.java
@@ -157,9 +157,10 @@ public class ControlFileModel extends Observable {
         if (position >  getColumnCount())
             throw new IllegalStateException("Cannot update field outside of the CSV");
         int index = getIndexOfColumnName(datasetFieldName);
-        // The same column cannot be mapped twice.  If the column is already mapped, set it to null
+        // The same column cannot be mapped twice.  If the column is already mapped, set the mapped version to be ignored
         if (index != -1 && index != position){
-            controlFile.getFileTypeControl().columns[index] = null;
+            controlFile.getFileTypeControl().columns[index] = ModelUtils.generatePlaceholderName(index);
+            ignoreColumnInCSVAtPosition(index);
         }
 
         removeIgnoredColumn(getColumnAtPosition(position));

--- a/src/main/java/com/socrata/datasync/ui/ControlFileEditFooterPanel.java
+++ b/src/main/java/com/socrata/datasync/ui/ControlFileEditFooterPanel.java
@@ -34,22 +34,8 @@ public class ControlFileEditFooterPanel extends JPanel {
             @Override
             public void actionPerformed(ActionEvent e) {
                 JobStatus status = model.validate();
-                // If all of the columns in the dataset aren't mapped, then provide the user with the option to
-                // ignore the unmapped ones
-                if (status == JobStatus.MISSING_COLUMNS){
-                    ArrayList<Column> unmappedColumns = model.getUnmappedDatasetColumns();
-                    int result = showIgnoreColumnsDialogBox(unmappedColumns);
-                    if (result == JOptionPane.YES_OPTION){
-                        //Ignore all of the unmapped columns
-                        for (Column unmapped : unmappedColumns) {
-                            model.ignoreColumnFromDataset(unmapped);
-                        }
-                        // Validate the model again in case there are other errors hiding behind this one
-                        status = model.validate();
-                    }
-                }
 
-                // If the job is still in an error state, then show the error to the user, and drop them back in the
+                // If the job is in an error state, then show the error to the user, and drop them back in the
                 // control file editor to fix it.  Otherwise, close the window.
                 if (status.isError()) {
                     validationPanel.displayStatus(status);
@@ -62,32 +48,6 @@ public class ControlFileEditFooterPanel extends JPanel {
             }
         });
         add(okButton);
-    }
-
-    private int showIgnoreColumnsDialogBox(ArrayList<Column> unmappedColumns){
-        Object[] options = {"Ignore columns", "Cancel"};
-        return JOptionPane.showOptionDialog(null,
-                getIgnoreColumnMessage(unmappedColumns),
-                "Unmapped columns",
-                JOptionPane.YES_NO_OPTION,
-                JOptionPane.WARNING_MESSAGE,
-                null, options, options[0]
-        );
-    }
-
-    private String getIgnoreColumnMessage(ArrayList<Column> unmappedColumns){
-
-        StringBuffer message = new StringBuffer("<HTML>The following columns exist in your dataset, but are not currently mapped:<br/>");
-        for (Column column : unmappedColumns){
-            message.append("<br/>   \u2022 " + getFriendlyColumnString(column));
-        }
-        message.append("<br/><br/>Would you like to ignore the columns (note that ignored columns will end up with \"null\" values)?");
-        message.append("</HTML>");
-        return message.toString();
-    }
-
-    private String getFriendlyColumnString(Column column){
-        return column.getName() + " (" + column.getFieldName() + ")";
     }
 
 }

--- a/src/main/java/com/socrata/datasync/ui/MappingPanel.java
+++ b/src/main/java/com/socrata/datasync/ui/MappingPanel.java
@@ -55,11 +55,11 @@ public class MappingPanel extends JPanel {
     private void updateCombobox(){
         String selection = model.getColumnAtPosition(index);
 
-        //Don't do anything if the selection hasn't changed (otherwise, you end up with a lot of events unnecessarily firing).
+        //Don't do anything if the state for the column hasn't changed (otherwise, you end up with a lot of events unnecessarily firing).
         if (selection == lastSelection)
             return;
 
-        if (selection == null || model.isIgnored(selection))
+        if (model.isIgnored(selection))
             columnNamesComboBox.setSelectedIndex(IGNORE_INDEX);
         else
             columnNamesComboBox.setSelectedItem(selection);


### PR DESCRIPTION
## Repro ##
1. Pick a CSV and a dataset to update 
2. Click map fields
3. Set the first field to map to a specific field in the dataset
4. Set the second field to map to the same field

Expected: That the first would say "ignore this column" and the second would map to the same field

Actual: Null pointer exception.  They both map to the same field. 

## Cause ##

Consumers of the ControlFileModel assume that the values in the columns array are
never null.  The code that manages collisions (e.g. I select "vendor"
for two different columns) was violating this assumption, setting the previous
value to null.  When this value was read later in the flow, we would get a null
pointer exception which would cause this to fail.

This commit also removes the dialog box which incorrectly prompted the user when
he or she had columns in the dataset which were not mapped, and they were trying to
do a replace.  Now, we simply inform them that they don't have a mapping and block
until they set a mapping.

QA: Verified that I was able to set and reset various columns.  Validated that I can still
update a dataset.  Verified that the output of the control file was correct.

Reviewed-by: TBD