### PR TITLE
Undoing replacePreviousQueued, directly conflicts with documentation

### DIFF
--- a/src/main/java/com/socrata/datasync/config/controlfile/ControlFile.java
+++ b/src/main/java/com/socrata/datasync/config/controlfile/ControlFile.java
@@ -17,22 +17,19 @@ public class ControlFile {
 
     public String action;
     public String opaque;
-
     public FileTypeControl csv;
     public FileTypeControl tsv;
-    public Boolean replacePreviousQueued;
 
     // NB: when using a mapper to read this class, you must enable
     // DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY, if either of the timestamp formats
     // in csvControl or tsvControl are strings, rather than arrays of strings.
     public ControlFile() {}
 
-    public ControlFile(String action, String opaque, FileTypeControl csvControl, FileTypeControl tsvControl, Boolean replacePreviousQueued) {
+    public ControlFile(String action, String opaque, FileTypeControl csvControl, FileTypeControl tsvControl) {
         this.action = action;
         this.opaque = opaque;
         this.csv = csvControl;
         this.tsv = tsvControl;
-
     }
 
 
@@ -113,9 +110,9 @@ public class ControlFile {
         }
 
         if (isCsv) {
-            return new ControlFile(Utils.capitalizeFirstLetter(publishMethod.name()), null, ftc, null, null);
+            return new ControlFile(Utils.capitalizeFirstLetter(publishMethod.name()), null, ftc, null);
         } else {
-            return new ControlFile(Utils.capitalizeFirstLetter(publishMethod.name()), null, null, ftc, null);
+            return new ControlFile(Utils.capitalizeFirstLetter(publishMethod.name()), null, null, ftc);
         }
     }
 

--- a/src/test/java/com/socrata/datasync/utilities/DeltaImporter2PublisherTest.java
+++ b/src/test/java/com/socrata/datasync/utilities/DeltaImporter2PublisherTest.java
@@ -47,7 +47,7 @@ public class DeltaImporter2PublisherTest extends TestBase {
     @Test
     public void testSerializationFullCommitMessage() throws IOException {
         FileTypeControl ftc = new FileTypeControl().floatingTimestampFormat(new String[]{"ISO8601"});
-        ControlFile cf = new ControlFile("Replace", null, ftc, null, true);
+        ControlFile cf = new ControlFile("Replace", null, ftc, null);
         CommitMessage commit = new CommitMessage()
                 .filename("hoo-ya.csv")
                 .relativeTo("datasync/id/some-4by4/completed/2014/6/2/hoo-ya.csv")
@@ -60,8 +60,7 @@ public class DeltaImporter2PublisherTest extends TestBase {
                     "\"action\":\"Replace\"," +
                     "\"csv\":{" +
                         "\"floatingTimestampFormat\":[\"ISO8601\"]" +
-                    "}," +
-                    "\"replacePreviousQueued\":true" +
+                    "}" +
                 "}," +
                 "\"expectedSize\":11001001," +
                 "\"filename\":\"hoo-ya.csv\"," +


### PR DESCRIPTION
'replacePreviousQueued' added to ControlFile in commit 5eaef048c99de18ff701e7fcaf38e8d0f66419d8,
Then the assignment of 'replacePreviousQueued' in the constructor was removed in commit 0860b0feb0193d1f14c48d71400b31ef34871283, making all references spaghetti code.

The constructor on the [documentation](http://socrata.github.io/datasync/guides/datasync-library-sdk.html) only has 4 parameters , these 'replacePreviouslyQueued' changes made the constructor take 5 parameters.
