### PR TITLE
EN-507 - Fix networking issues with DataSync 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ mvn clean compile -Dmaven.test.skip=true assembly:single
 This puts the JAR file into the "target" directory inside the repo.  So to open DataSync, simply:
 ```
 cd target
-java -jar DataSync-1.7-jar-with-dependencies.jar
+java -jar DataSync-1.7.1-jar-with-dependencies.jar
 ```
 
 ### Java SDK

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>DataSync</groupId>
     <artifactId>DataSync</artifactId>
-    <version>1.7</version>
+    <version>1.7.1</version>
     <developers>
         <developer>
             <name>Ayn Leslie-Cook</name>

--- a/src/main/java/com/socrata/datasync/DatasetUtils.java
+++ b/src/main/java/com/socrata/datasync/DatasetUtils.java
@@ -38,7 +38,7 @@ public class DatasetUtils {
                 .setPath("/api/views/" + viewId)
                 .build();
 
-        CloseableHttpResponse resp = get(userPrefs,absolutePath,"application/json");
+        CloseableHttpResponse resp = get(userPrefs, absolutePath, "application/json");
 
         return mapper.readValue(resp.getEntity().getContent(), Dataset.class);
     }
@@ -52,7 +52,7 @@ public class DatasetUtils {
                 .addParameter("$limit",""+rowsToSample)
                 .build();
 
-        CloseableHttpResponse resp = get(userPrefs,absolutePath,"application/csv");
+        CloseableHttpResponse resp = get(userPrefs, absolutePath, "application/csv");
 
         HttpEntity entity = resp.getEntity();
 

--- a/src/test/java/com/socrata/datasync/VersionProviderTest.java
+++ b/src/test/java/com/socrata/datasync/VersionProviderTest.java
@@ -48,6 +48,6 @@ public class VersionProviderTest {
 
     @Test
     public void testGetThisVersion() {
-        TestCase.assertEquals("1.7", VersionProvider.getThisVersion());
+        TestCase.assertEquals("1.7.1", VersionProvider.getThisVersion());
     }
 }

--- a/src/test/java/com/socrata/datasync/model/ControlFileModelTest.java
+++ b/src/test/java/com/socrata/datasync/model/ControlFileModelTest.java
@@ -6,7 +6,7 @@ import com.socrata.datasync.config.controlfile.LocationColumn;
 import com.socrata.datasync.config.userpreferences.UserPreferences;
 import com.socrata.datasync.config.userpreferences.UserPreferencesFile;
 import com.socrata.exceptions.LongRunningQueryException;
-import com.socrata.exceptions.SodaError;
+import org.apache.http.HttpException;
 import junit.framework.TestCase;
 import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 /**
  * Series of tests to validate that the control file model produces a correct control file.
@@ -26,7 +27,7 @@ public class ControlFileModelTest extends TestBase {
     ObjectMapper mapper = new ObjectMapper().enable(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 
     @Test
-    public void testColumnUpdates() throws IOException, LongRunningQueryException, InterruptedException, SodaError {
+    public void testColumnUpdates() throws IOException, LongRunningQueryException, InterruptedException, HttpException, URISyntaxException {
         ControlFile cf = getTestControlFile();
         ControlFileModel model = getTestModel(cf);
 
@@ -37,7 +38,7 @@ public class ControlFileModelTest extends TestBase {
 
     //Can I get out the same control file that I put in?
     @Test
-    public void testSerialization() throws IOException, LongRunningQueryException, InterruptedException, SodaError {
+    public void testSerialization() throws IOException, LongRunningQueryException, InterruptedException, HttpException, URISyntaxException {
 
         ControlFile cf = getTestControlFile();
         ObjectMapper mapper = new ObjectMapper().configure(SerializationConfig.Feature.INDENT_OUTPUT, true);
@@ -48,7 +49,7 @@ public class ControlFileModelTest extends TestBase {
     }
 
     @Test
-    public void testIgnoredColumns() throws IOException, LongRunningQueryException, InterruptedException, SodaError {
+    public void testIgnoredColumns() throws IOException, LongRunningQueryException, InterruptedException, HttpException, URISyntaxException {
         ControlFile cf = getTestControlFile();
         ControlFileModel model = getTestModel(cf);
         int columnLengthBeforeUpdate = model.getColumnCount();
@@ -64,7 +65,7 @@ public class ControlFileModelTest extends TestBase {
     }
 
     @Test
-    public void testHasHeaderRow() throws IOException, LongRunningQueryException, InterruptedException, SodaError {
+    public void testHasHeaderRow() throws IOException, LongRunningQueryException, InterruptedException, HttpException, URISyntaxException {
         //Assert that we are skipping the first row when has header row == 1
         ControlFile cf = getTestControlFile();
         ControlFileModel model = getTestModel(cf);
@@ -81,7 +82,7 @@ public class ControlFileModelTest extends TestBase {
 
 
     @Test
-    public void testSyntheticColumns() throws IOException, LongRunningQueryException, InterruptedException, SodaError {
+    public void testSyntheticColumns() throws IOException, LongRunningQueryException, InterruptedException, HttpException, URISyntaxException {
         ControlFile cf = getTestControlFile();
         ControlFileModel model = getTestModel(cf);
 
@@ -109,11 +110,11 @@ public class ControlFileModelTest extends TestBase {
         return cf;
     }
 
-    private ControlFileModel getTestModel(ControlFile cf) throws IOException, LongRunningQueryException, InterruptedException, SodaError {
+    private ControlFileModel getTestModel(ControlFile cf) throws IOException, LongRunningQueryException, InterruptedException, HttpException, URISyntaxException {
         File configFile = new File(PATH_TO_CONFIG_FILE);
         ObjectMapper mapper = new ObjectMapper();
         UserPreferences userPrefs = mapper.readValue(configFile, UserPreferencesFile.class);
-        DatasetModel datasetModel = new DatasetModel(userPrefs.getDomain(),userPrefs.getUsername(),userPrefs.getPassword(),userPrefs.getAPIKey(),TestBase.UNITTEST_DATASET_ID);
+        DatasetModel datasetModel = new DatasetModel(userPrefs,TestBase.UNITTEST_DATASET_ID);
         ControlFileModel model = new ControlFileModel(cf,datasetModel);
         return model;
     }


### PR DESCRIPTION
There are a number of customers who are reporting networking
issues with DataSync 1.6.  In particular, when you click "Map
fields," the client does a bad SSL handshake and the client's firewall
shuts down the connection.  Note that this does not repro when using
DataSync from the command line.

The root cause of this appears to be soda-java's use of the Jersey
client. Since this only repros when using Soda-java, I'm simply changing
this flow to use the HttpUtility which we know already works.  FWIW,
I did try and upgrade soda-java to Jersey 2.22 and the 4.5.3 Apache Client.  
However, it continued to hit the same renegotiation issues.

QA: Verified with Peter Moore that it fixes customer issue.  Regression tests