### PR TITLE
EN-5650: Socket is closed

### DIFF
--- a/src/main/java/com/socrata/datasync/DatasetUtils.java
+++ b/src/main/java/com/socrata/datasync/DatasetUtils.java
@@ -55,7 +55,7 @@ public class DatasetUtils {
         };
 
         HttpUtility util = new HttpUtility(userPrefs, true);
-        Dataset datasetInfo = util.get(absolutePath, "application/json",handler);
+        Dataset datasetInfo = util.get(absolutePath, "application/json", handler);
         util.close();
         return datasetInfo;
     }
@@ -85,7 +85,7 @@ public class DatasetUtils {
         };
 
         HttpUtility util = new HttpUtility(userPrefs, true);
-        String sample = util.get(absolutePath, "application/csv",handler);
+        String sample = util.get(absolutePath, "application/csv", handler);
         util.close();
         return sample;
     }

--- a/src/main/java/com/socrata/datasync/DatasetUtils.java
+++ b/src/main/java/com/socrata/datasync/DatasetUtils.java
@@ -40,7 +40,17 @@ public class DatasetUtils {
 
         CloseableHttpResponse resp = get(userPrefs, absolutePath, "application/json");
 
-        return mapper.readValue(resp.getEntity().getContent(), Dataset.class);
+        Dataset datasetInfo;
+        try {
+            HttpEntity entity = resp.getEntity();
+            EntityUtils.consume(entity);
+            datasetInfo = mapper.readValue(resp.getEntity().getContent(), Dataset.class);
+        }
+        finally {
+            resp.close();
+        }
+
+        return datasetInfo;
     }
 
     public static String getDatasetSample(UserPreferences userPrefs, String viewId, int rowsToSample) throws URISyntaxException, IOException, HttpException {
@@ -54,9 +64,17 @@ public class DatasetUtils {
 
         CloseableHttpResponse resp = get(userPrefs, absolutePath, "application/csv");
 
-        HttpEntity entity = resp.getEntity();
+        String sample;
+        try {
+            HttpEntity entity = resp.getEntity();
+            EntityUtils.consume(entity);
+            sample = EntityUtils.toString(entity,"UTF-8");
+        }
+        finally {
+            resp.close();
+        }
 
-        return EntityUtils.toString(entity,"UTF-8");
+        return sample;
     }
 
     private static String getDomainWithoutScheme(UserPreferences userPrefs){

--- a/src/main/java/com/socrata/datasync/HttpUtility.java
+++ b/src/main/java/com/socrata/datasync/HttpUtility.java
@@ -12,6 +12,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -88,6 +89,16 @@ public class HttpUtility {
      * @return the unproccessed query results
      */
     public CloseableHttpResponse get(URI uri, String contentType) throws IOException {
+        HttpGet httpGet = buildHttpGet(uri,contentType);
+        return httpClient.execute(httpGet);
+    }
+
+    public <T> T get(URI uri, String contentType, ResponseHandler<T> handler) throws IOException {
+        HttpGet httpGet = buildHttpGet(uri,contentType);
+        return httpClient.execute(httpGet,handler);
+    }
+
+    private HttpGet buildHttpGet(URI uri, String contentType){
         HttpGet httpGet = new HttpGet(uri);
         httpGet.setHeader(HttpHeaders.USER_AGENT, userAgent);
         httpGet.addHeader(HttpHeaders.ACCEPT, contentType);
@@ -98,7 +109,7 @@ public class HttpUtility {
             httpGet.setHeader(appHeader, appToken);
             httpGet.setHeader(HttpHeaders.AUTHORIZATION, authHeader);
         }
-        return httpClient.execute(httpGet);
+        return httpGet;
     }
 
     /**


### PR DESCRIPTION
When we leave the scope of the try block in DatasetUtils.get, the
socket on the CloseableHttpResponse is automatically closed.  This
happens before we consume the contents.  This leads to some
conditions (not all) where reading the stream throws a socket closed
exception.

The fix is to use a more common pattern with the HttpClient by passing
a response handler to the client.  This handler is executed in scope
thus bypassing this issue.