### PR TITLE
Fix parsing CSVs from Socrata

### DIFF
--- a/src/main/java/com/socrata/datasync/DatasetUtils.java
+++ b/src/main/java/com/socrata/datasync/DatasetUtils.java
@@ -116,7 +116,7 @@ public class DatasetUtils {
         String sample = util.get(absolutePath, "application/csv", handler);
         util.close();
 
-        CSVReader reader = new CSVReader(new StringReader(sample));
+        CSVReader reader = new CSVReader(new StringReader(sample), ',', '"', '\u0000');
 
         List<List<String>> results = new ArrayList<>();
 


### PR DESCRIPTION
Our CSVs follow the RFC, and therefore do not escape anything with
backslash.  So tell OpenCSV that the escape character is NUL (which
will also never be in our CSVs because you cannot store a NUL in a
postgresql string) in order to prevent misunderstandings.