### PR TITLE
EN-49082: rework column-matching

### DIFF
--- a/src/main/java/com/socrata/datasync/model/ControlFileModel.java
+++ b/src/main/java/com/socrata/datasync/model/ControlFileModel.java
@@ -50,7 +50,7 @@ public class ControlFileModel extends Observable {
     private DatasetModel datasetModel;
     private String path;
 
-    public ControlFileModel (ControlFile file, DatasetModel dataset) throws IOException{
+    public ControlFileModel (ControlFile file, DatasetModel dataset, boolean isPostNbeification) throws IOException{
         controlFile = file;
         if (controlFile.getFileTypeControl().hasHeaderRow)
             controlFile.getFileTypeControl().skip = 1;
@@ -63,10 +63,11 @@ public class ControlFileModel extends Observable {
         // could be duplicates, as well as empty strings.
         if (!file.getFileTypeControl().hasColumns()){
             initializeColumns();
+            // Now attempt to match those in the dataset to those in the CSV
+            matchColumns();
+        } else if(!isPostNbeification) {
+            matchColumns();
         }
-
-        // Now attempt to match those in the dataset to those in the CSV
-        matchColumns();
     }
 
     //This will be called anytime that we think the shape of the dataset has changed underneath us.

--- a/src/main/java/com/socrata/datasync/ui/IntegrationJobTab.java
+++ b/src/main/java/com/socrata/datasync/ui/IntegrationJobTab.java
@@ -120,6 +120,7 @@ public class IntegrationJobTab implements JobTab {
     private JTextField runCommandTextField;
 
     private boolean usingControlFile;
+    private boolean jobFromPostNbeification;
 
     private UserPreferences userPrefs;
 
@@ -236,6 +237,7 @@ public class IntegrationJobTab implements JobTab {
 
     private void loadJobDataIntoUIFields(IntegrationJob job)  {
         try {
+            jobFromPostNbeification = job.getIsPostNbeification();
             if (job.getControlFileContent() != null) {
                 ObjectMapper mapper = new ObjectMapper().enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
                 ControlFile controlFile = mapper.readValue(job.getControlFileContent(), ControlFile.class);
@@ -283,8 +285,8 @@ public class IntegrationJobTab implements JobTab {
 
         datasetModel = new DatasetModel(userPrefs, fourbyfour);
 
-        controlFileModel = new ControlFileModel(controlFile, datasetModel);
-
+        controlFileModel = new ControlFileModel(controlFile, datasetModel, jobFromPostNbeification);
+        jobFromPostNbeification = true;
     }
 
     private void updatePublishViaReplaceUIFields(boolean showFileInfo) {
@@ -340,6 +342,7 @@ public class IntegrationJobTab implements JobTab {
         newIntegrationJob.setPathToControlFile(controlFileModel.getPath());
         newIntegrationJob.setControlFileContent(controlFileModel.getControlFileContents());
         newIntegrationJob.setPathToSavedFile(jobFileLocation);
+        newIntegrationJob.setIsPostNbeification(true);
 
         // TODO If an existing file was selected WARN user of overwriting
         // if first time saving this job: Open dialog box to select "Save as..." location


### PR DESCRIPTION
As a result of the NBE change we wanted to be a little fuzzy on matching
CSV/dataset columns, but this turned out to be too eager.  Now that the
NBE is everywhere, let's only do that if we're dealing with a job file
from before that change, where "before that change" is defined as "not
having a flag that says it's from after that change".